### PR TITLE
fix: routing table

### DIFF
--- a/neurons/__init__.py
+++ b/neurons/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.5.7"
+__version__ = "2.5.8"
 version_split = __version__.split(".")
 version_numerical = (
     (100 * int(version_split[0]))

--- a/validator/node_manager.py
+++ b/validator/node_manager.py
@@ -203,11 +203,20 @@ class NodeManager:
                 )
                 keys_to_delete.append(hotkey)
 
-        for hotkey in keys_to_delete:
-            del self.connected_nodes[hotkey]
+        # Only process if there are actually disconnected nodes
+        if keys_to_delete:
+            for hotkey in keys_to_delete:
+                del self.connected_nodes[hotkey]
+                # Remove only this specific miner's entries from routing table
+                self.validator.routing_table.clear_miner(hotkey)
 
-        self.validator.connected_tee_list = []
-        await self.update_tee_list()
+            logger.info(
+                f"Cleaned up {len(keys_to_delete)} disconnected miners from routing table"
+            )
+
+        # REMOVED: No longer clearing the entire connected_tee_list
+        # REMOVED: No longer forcing a full update_tee_list() rebuild
+        # The routing table now maintains its state and only removes specific disconnected miners
 
     async def send_custom_message(self, node_hotkey: str, message: str) -> None:
         """


### PR DESCRIPTION
## Fix Routing Table Oscillation by Removing Unnecessary TEE List Clearing

### Problem
The routing table was experiencing a growth/shrink/growth pattern where the table would:
1. Grow as miners were added during `update_tee_list()`
2. Shrink dramatically when `remove_disconnected_nodes()` cleared the entire TEE list
3. Grow again as the full rebuild process re-discovered existing miners

This oscillation was caused by the `remove_disconnected_nodes()` method unnecessarily clearing the entire `connected_tee_list` and forcing a complete routing table rebuild on every metagraph sync cycle (every 30-60 seconds).

### Solution
Modified `remove_disconnected_nodes()` to be surgical rather than destructive:

**Before:**
- Cleared entire `connected_tee_list = []` regardless of how many nodes disconnected
- Forced full `update_tee_list()` rebuild every sync cycle
- Caused routing table to oscillate between full and empty states

**After:**
- Only processes cleanup when nodes are actually disconnected
- Removes only specific disconnected miners using `routing_table.clear_miner(hotkey)`
- Preserves valid routing table entries between sync cycles
- No unnecessary full rebuilds

### Benefits
- **Eliminates oscillation**: Routing table size remains stable between sync cycles
- **Improves performance**: Avoids expensive full rebuilds when no miners disconnect
- **Preserves valid data**: Connected miners stay in the routing table
- **Surgical cleanup**: Only removes miners that are actually deregistered from the metagraph
- **Better logging**: Shows exactly how many miners were cleaned up

### Impact
The routing table will now grow steadily as new miners connect and only shrink when miners actually disconnect from the network, eliminating the problematic growth/shrink pattern.
